### PR TITLE
Fix memory access violation when calling powershell_reflective_mimikatz ...

### DIFF
--- a/mimikatz/mimikatz.c
+++ b/mimikatz/mimikatz.c
@@ -195,6 +195,7 @@ __declspec(dllexport) wchar_t * powershell_reflective_mimikatz(LPCWSTR input)
 	if(argv = CommandLineToArgvW(input, &argc))
 	{
 		outputBufferElements = 0xff;
+		outputBufferElementsPosition = 0;
 		if(outputBuffer = (wchar_t *) LocalAlloc(LPTR, outputBufferElements))
 			wmain(argc, argv);
 		LocalFree(argv);


### PR DESCRIPTION
Fix memory access violation when calling powershell_reflective_mimikatz more than once.
