### PR TITLE
Fix warnings that prevent compiling

### DIFF
--- a/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
+++ b/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
@@ -2351,14 +2351,15 @@ void __RPC_USER SRV_DRS_HANDLE_rundown(DRS_HANDLE hDrs)
 // higher version implies changes (like adding schemasignature in replication metadata)
 ULONG SRV_IDL_DRSBind(handle_t rpc_handle, UUID *puuidClientDsa, DRS_EXTENSIONS *pextClient, DRS_EXTENSIONS **ppextServer, DRS_HANDLE *phDrs)
 {
-	ULONG status, size;
+	ULONG status;
+	LONG size;
 	if(pextClient && ppextServer && phDrs && ((PDRS_EXTENSIONS_INT) pextClient)->cb >= FIELD_OFFSET(DRS_EXTENSIONS_INT, SiteObjGuid) - sizeof(DWORD))
 	{
 		if(((PDRS_EXTENSIONS_INT) pextClient)->dwFlags & DRS_EXT_GETCHGREPLY_V6)
 		{
 			if(((PDRS_EXTENSIONS_INT) pextClient)->dwFlags & DRS_EXT_STRONG_ENCRYPTION)
 			{
-				size = ((PDRS_EXTENSIONS_INT) pextClient)->cb >= FIELD_OFFSET(DRS_EXTENSIONS_INT, dwFlagsExt) ? FIELD_OFFSET(DRS_EXTENSIONS_INT, dwFlagsExt) : FIELD_OFFSET(DRS_EXTENSIONS_INT, SiteObjGuid);
+				size = ((PDRS_EXTENSIONS_INT) pextClient)->cb >= (ULONG)FIELD_OFFSET(DRS_EXTENSIONS_INT, dwFlagsExt) ? FIELD_OFFSET(DRS_EXTENSIONS_INT, dwFlagsExt) : FIELD_OFFSET(DRS_EXTENSIONS_INT, SiteObjGuid);
 				if(*ppextServer = (DRS_EXTENSIONS *) midl_user_allocate(size))
 				{
 					RtlZeroMemory(*ppextServer, size);


### PR DESCRIPTION
With the current "SRV_IDL_DRSBind", there are two comparisons made between signed and unsigned LONGs (lines 2361 and 2369).
This is because FIELD_OFFSET returns a LONG, but the value you are comparing it with (cb) is a ULONG. In visual studio the project settings for mimikatz will treat warnings as errors and won't compile.

To fix it, I've changed size from a ULONG to a LONG (line 2355) because it will only every be assigned a LONG value, and I cast the initial FIELD_OFFSET comparison as a ULONG (line 2362). This fixes both warnings and allows the project to compile with no warnings.

[Issue 133](https://github.com/gentilkiwi/mimikatz/issues/133) created