### PR TITLE
Stop parsing commands on EOF

### DIFF
--- a/mimikatz/mimikatz.c
+++ b/mimikatz/mimikatz.c
@@ -51,7 +51,8 @@ int wmain(int argc, wchar_t * argv[])
 	while (status != STATUS_FATAL_APP_EXIT)
 	{
 		kprintf(L"\n" MIMIKATZ L" # "); fflush(stdin);
-		if(fgetws(input, ARRAYSIZE(input), stdin) && (len = wcslen(input)) && (input[0] != L'\n'))
+		if (fgetws(input, ARRAYSIZE(input), stdin) == NULL) break;
+		if((len = wcslen(input)) && input[0] != L'\n')
 		{
 			if(input[len - 1] == L'\n')
 				input[len - 1] = L'\0';


### PR DESCRIPTION
Previously, the shell hung in an infinite `fgetws()` loop if EOF was encountered unexpectedly.