### PR TITLE
Remove check for '.' in domain name for dcsync

### DIFF
--- a/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
+++ b/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
@@ -44,7 +44,9 @@ NTSTATUS kuhl_m_lsadump_dcsync(int argc, wchar_t * argv[])
 		if(kull_m_net_getCurrentDomainInfo(&pPolicyDnsDomainInfo))
 			szDomain = pPolicyDnsDomainInfo->DnsDomainName.Buffer;
 
-	if(szDomain && wcschr(szDomain, L'.'))
+	// Don't check for a period in the FQDN because it's possible that the domain doesn't have one!
+	// Instead, we'll just check to make sure we have a domain specified and that is has at least one character.
+	if(szDomain && wcslen(szDomain) > 0)
 	{
 		kprintf(L"[DC] \'%s\' will be the domain\n", szDomain);
 		if(!(kull_m_string_args_byName(argc, argv, L"dc", &szDc, NULL) || kull_m_string_args_byName(argc, argv, L"kdc", &szDc, NULL)))


### PR DESCRIPTION
The code in dcsync was checking to make sure that the domain name provided either by the user or by the result of an API call was an FQDN. To do this, it was checking that a period ('.') was present in the name. Often FQDNs contain periods, however I was on a gig recently that had at least one domain that did not have a period in the FQDN, and as a result the calls to dcsync were failing.

This PR updates mimikatz so that it no longer checks for the period in the FQDN, and assumes that the user knows what they're doing!