### PR TITLE
Add more support for Windows 10 x64

### DIFF
--- a/mimikatz/modules/kuhl_m_lsadump.c
+++ b/mimikatz/modules/kuhl_m_lsadump.c
@@ -494,6 +494,15 @@ BOOL kuhl_m_lsadump_getSamKey(PKULL_M_REGISTRY_HANDLE hRegistry, HKEY hAccount, 
 				if(!(status = NT_SUCCESS(RtlEncryptDecryptRC4(&data, &key))))
 					PRINT_ERROR(L"RtlEncryptDecryptRC4 KO");
 			}
+            else if (pDomAccF->keys1.Revision == 2) {
+				pAesKey = (PSAM_KEY_DATA_AES)&pDomAccF->keys1;
+				if (kull_m_crypto_genericAES128Decrypt(sysKey, pAesKey->Salt, pAesKey->data, pAesKey->DataLen, &out, &len))
+				{
+					if (status = (len == SAM_KEY_DATA_KEY_LENGTH))
+						RtlCopyMemory(samKey, out, SAM_KEY_DATA_KEY_LENGTH);
+					LocalFree(out);
+				}
+			}
 			else PRINT_ERROR(L"Unknow Classic Struct Key revision (%u)", pDomAccF->keys1.Revision);
 			break;
 		case 3:


### PR DESCRIPTION
In some SAM hives from Windows 10 x64, `pDomAccF->Revision` is 2 but also `keys1.Revision` returns 2. This PR will allow these SAM hives to be processed. This fix is taken from and closes #99.