### PR TITLE
Issue #282: Fix bug when sekurlsa::(logonpasswords,msv,tspkg) is ran twice

### DIFF
--- a/mimikatz/modules/sekurlsa/kuhl_m_sekurlsa.c
+++ b/mimikatz/modules/sekurlsa/kuhl_m_sekurlsa.c
@@ -438,6 +438,7 @@ void kuhl_m_sekurlsa_printinfos_logonData(IN PKIWI_BASIC_SECURITY_LOGON_SESSION_
 
 NTSTATUS kuhl_m_sekurlsa_getLogonData(const PKUHL_M_SEKURLSA_PACKAGE * lsassPackages, ULONG nbPackages)
 {
+	kuhl_m_sekurlsa_reset();
 	KUHL_M_SEKURLSA_GET_LOGON_DATA_CALLBACK_DATA OptionalData = {lsassPackages, nbPackages};
 	return kuhl_m_sekurlsa_enum(kuhl_m_sekurlsa_enum_callback_logondata, &OptionalData);
 }


### PR DESCRIPTION
Fixes issue: 282 by running kuhl_m_sekurlsa_reset(); prior to running sekurlsa commands.  This was being done in some, but not all commands.