### PR TITLE
mimidrv: Fix build on VS2019

### DIFF
--- a/mimidrv/mimidrv.vcxproj
+++ b/mimidrv/mimidrv.vcxproj
@@ -19,7 +19,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v100</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <OutDir>$(SolutionDir)$(Platform)\</OutDir>
     <IntDir>$(Platform)\</IntDir>


### PR DESCRIPTION
Fix build on VS2019 by referencing `Microsoft.Cpp.Default.props` instead of `Microsoft.Cpp.props`