### PR TITLE
Prevent infinite loop in main

### DIFF
--- a/mimikatz/mimikatz.c
+++ b/mimikatz/mimikatz.c
@@ -53,12 +53,20 @@ int wmain(int argc, wchar_t * argv[])
 	while ((status != STATUS_PROCESS_IS_TERMINATING) && (status != STATUS_THREAD_IS_TERMINATING))
 	{
 		kprintf(L"\n" MIMIKATZ L" # "); fflush(stdin);
-		if(fgetws(input, ARRAYSIZE(input), stdin) && (len = wcslen(input)) && (input[0] != L'\n'))
+		if (fgetws(input, ARRAYSIZE(input), stdin))
 		{
-			if(input[len - 1] == L'\n')
-				input[len - 1] = L'\0';
-			kprintf_inputline(L"%s\n", input);
-			status = mimikatz_dispatchCommand(input);
+			if ((len = wcslen(input)) && (input[0] != L'\n'))
+			{
+				if (input[len - 1] == L'\n')
+					input[len - 1] = L'\0';
+				kprintf_inputline(L"%s\n", input);
+				status = mimikatz_dispatchCommand(input);
+			}
+		}
+		else
+		{
+			// Unable to read from stdin, so break
+			break;
 		}
 	}
 #endif


### PR DESCRIPTION
In contexts with no usable `stdin` (for instance, PSRemoting), the prompt would loop forever. This patch checks the return value of `fgetws` and breaks if it indicates an error in reading.