### PR TITLE
[fix] type cast: pointer truncation, x64 build

### DIFF
--- a/mimikatz/modules/kuhl_m_ts.c
+++ b/mimikatz/modules/kuhl_m_ts.c
@@ -477,7 +477,7 @@ void kuhl_m_ts_mstsc_MemoryAnalysis_property(PKULL_M_MEMORY_HANDLE hMemory, PVOI
 							switch(pProperties[i].dwType)
 							{
 							case 1:
-								kprintf(L"[ dword ] %u (0x%08x)", (DWORD) pProperties[i].pvData, (DWORD) pProperties[i].pvData);
+								kprintf(L"[ dword ] %u (0x%08x)", (DWORD_PTR) pProperties[i].pvData, (DWORD_PTR) pProperties[i].pvData);
 								break;
 
 							case 2:
@@ -485,7 +485,7 @@ void kuhl_m_ts_mstsc_MemoryAnalysis_property(PKULL_M_MEMORY_HANDLE hMemory, PVOI
 								break;
 
 							case 3:
-								kprintf(L"[ bool  ] %s", ((BOOL) pProperties[i].pvData) ? L"TRUE" : L"FALSE");
+								kprintf(L"[ bool  ] %s", (pProperties[i].pvData) ? L"TRUE" : L"FALSE");
 								break;
 
 							case 4:
@@ -501,18 +501,18 @@ void kuhl_m_ts_mstsc_MemoryAnalysis_property(PKULL_M_MEMORY_HANDLE hMemory, PVOI
 
 							case 6:
 								kprintf(L"[protect] ");
-								if(pProperties[i].pvData && (DWORD) pProperties[i].unkp2)
+								if(pProperties[i].pvData && (DWORD_PTR) pProperties[i].unkp2)
 								{
-									aDataBuffer.address = (PBYTE) LocalAlloc(LPTR, (DWORD) pProperties[i].unkp2);
+									aDataBuffer.address = (PBYTE) LocalAlloc(LPTR, (DWORD_PTR) pProperties[i].unkp2);
 
 									if(aDataBuffer.address)
 									{
 										aProcess.address = pProperties[i].pvData;
-										if(kull_m_memory_copy(&aDataBuffer, &aProcess, (DWORD) pProperties[i].unkp2))
+										if(kull_m_memory_copy(&aDataBuffer, &aProcess, (DWORD_PTR) pProperties[i].unkp2))
 										{
 											if(pProperties[i].dwFlags & 0x800)
 											{
-												if(kull_m_crypto_remote_CryptUnprotectMemory(aProcess.hMemory, aDataBuffer.address, (DWORD) pProperties[i].unkp2, CRYPTPROTECTMEMORY_SAME_PROCESS))
+												if(kull_m_crypto_remote_CryptUnprotectMemory(aProcess.hMemory, aDataBuffer.address, (DWORD_PTR) pProperties[i].unkp2, CRYPTPROTECTMEMORY_SAME_PROCESS))
 												{
 													kprintf(L"\'%.*s\'", *(PDWORD) aDataBuffer.address / sizeof(wchar_t), ((PBYTE) aDataBuffer.address) + sizeof(DWORD));
 												}
@@ -520,7 +520,7 @@ void kuhl_m_ts_mstsc_MemoryAnalysis_property(PKULL_M_MEMORY_HANDLE hMemory, PVOI
 											}
 											else
 											{
-												kull_m_string_wprintf_hex(aDataBuffer.address, (DWORD) pProperties[i].unkp2, 0);
+												kull_m_string_wprintf_hex(aDataBuffer.address, (DWORD_PTR) pProperties[i].unkp2, 0);
 											}
 										}
 										LocalFree(aDataBuffer.address);

--- a/mimikatz/modules/ngc/kuhl_m_ngc.c
+++ b/mimikatz/modules/ngc/kuhl_m_ngc.c
@@ -18,7 +18,7 @@ const KUHL_M kuhl_m_ngc = {
 	ARRAYSIZE(kuhl_m_c_ngc), kuhl_m_c_ngc, NULL, NULL
 };
 
-typedef BOOL (WINAPI * PCRYPTUNPROTECTMEMORY) (__inout LPVOID pDataIn, __in DWORD cbDataIn, __in DWORD dwFlags);
+typedef BOOL (WINAPI * PCRYPTUNPROTECTMEMORY) (__inout LPVOID pDataIn, __in DWORD_PTR cbDataIn, __in DWORD dwFlags);
 #pragma optimize("", off)
 DWORD WINAPI kiwidecode_thread(PREMOTE_LIB_DATA lpParameter)
 {

--- a/modules/kull_m_crypto_remote.c
+++ b/modules/kull_m_crypto_remote.c
@@ -17,7 +17,7 @@ DWORD WINAPI kull_m_crypto_remote_thread_CryptProtectMemory_Generic(PREMOTE_LIB_
 DWORD kull_m_crypto_remote_thread_CryptProtectMemory_Generic_end(){return 'kipr';}
 #pragma optimize("", on)
 
-BOOL WINAPI kull_m_crypto_remote_CryptProtectMemory_Generic(__in PKULL_M_MEMORY_HANDLE hProcess, __in BOOL bIsProtect, __inout LPVOID pDataIn, __in DWORD cbDataIn, __in DWORD dwFlags)
+BOOL WINAPI kull_m_crypto_remote_CryptProtectMemory_Generic(__in PKULL_M_MEMORY_HANDLE hProcess, __in BOOL bIsProtect, __inout LPVOID pDataIn, __in DWORD_PTR cbDataIn, __in DWORD dwFlags)
 {
 	BOOL status = FALSE;
 	PREMOTE_LIB_INPUT_DATA iData;

--- a/modules/kull_m_crypto_remote.h
+++ b/modules/kull_m_crypto_remote.h
@@ -8,9 +8,9 @@
 #include "kull_m_remotelib.h"
 
 //typedef BOOL (WINAPI * PCRYPTPROTECTMEMORY) (__inout LPVOID pDataIn, __in DWORD cbDataIn, __in DWORD dwFlags);
-typedef BOOL (WINAPI * PCRYPTUNPROTECTMEMORY) (__inout LPVOID pDataIn, __in DWORD cbDataIn, __in DWORD dwFlags);
+typedef BOOL (WINAPI * PCRYPTUNPROTECTMEMORY) (__inout LPVOID pDataIn, __in DWORD_PTR cbDataIn, __in DWORD dwFlags);
 
-BOOL WINAPI kull_m_crypto_remote_CryptProtectMemory_Generic(__in PKULL_M_MEMORY_HANDLE hProcess, __in BOOL bIsProtect, __inout LPVOID pDataIn, __in DWORD cbDataIn, __in DWORD dwFlags);
+BOOL WINAPI kull_m_crypto_remote_CryptProtectMemory_Generic(__in PKULL_M_MEMORY_HANDLE hProcess, __in BOOL bIsProtect, __inout LPVOID pDataIn, __in DWORD_PTR cbDataIn, __in DWORD dwFlags);
 
 #define kull_m_crypto_remote_CryptProtectMemory(hProcess, pDataIn, cbDataIn, dwFlags)	kull_m_crypto_remote_CryptProtectMemory_Generic(hProcess, TRUE, pDataIn, cbDataIn, dwFlags)
 #define kull_m_crypto_remote_CryptUnprotectMemory(hProcess, pDataIn, cbDataIn, dwFlags)	kull_m_crypto_remote_CryptProtectMemory_Generic(hProcess, FALSE, pDataIn, cbDataIn, dwFlags)

--- a/modules/kull_m_remotelib.c
+++ b/modules/kull_m_remotelib.c
@@ -5,7 +5,7 @@
 */
 #include "kull_m_remotelib.h"
 
-PREMOTE_LIB_INPUT_DATA kull_m_remotelib_CreateInput(PVOID inputVoid, DWORD inputDword, DWORD inputSize, LPCVOID inputData)
+PREMOTE_LIB_INPUT_DATA kull_m_remotelib_CreateInput(PVOID inputVoid, DWORD inputDword, DWORD_PTR inputSize, LPCVOID inputData)
 {
 	PREMOTE_LIB_INPUT_DATA iData;
 	if(iData = (PREMOTE_LIB_INPUT_DATA) LocalAlloc(LPTR, FIELD_OFFSET(REMOTE_LIB_INPUT_DATA, inputData) + inputSize))
@@ -30,7 +30,7 @@ BOOL kull_m_remotelib_create(PKULL_M_MEMORY_ADDRESS aRemoteFunc, PREMOTE_LIB_INP
 	PREMOTE_LIB_DATA data;
 	REMOTE_LIB_OUTPUT_DATA oData;
 	MIMIDRV_THREAD_INFO drvInfo = {(PTHREAD_START_ROUTINE) aRemoteFunc->address, NULL};
-	DWORD size = FIELD_OFFSET(REMOTE_LIB_DATA, input.inputData) + input->inputSize;
+	DWORD_PTR size = FIELD_OFFSET(REMOTE_LIB_DATA, input.inputData) + input->inputSize;
 
 	if(!output)
 		output = &oData;

--- a/modules/kull_m_remotelib.h
+++ b/modules/kull_m_remotelib.h
@@ -11,14 +11,14 @@ typedef struct _REMOTE_LIB_OUTPUT_DATA {
 	PVOID		outputVoid;
 	DWORD		outputDword;
 	NTSTATUS	outputStatus;
-	DWORD		outputSize;
+	DWORD_PTR	outputSize;
 	PVOID		outputData;
 } REMOTE_LIB_OUTPUT_DATA, *PREMOTE_LIB_OUTPUT_DATA;
 
 typedef struct _REMOTE_LIB_INPUT_DATA {
 	PVOID		inputVoid;
 	DWORD		inputDword;
-	DWORD		inputSize;
+	DWORD_PTR	inputSize;
 	BYTE		inputData[ANYSIZE_ARRAY];
 } REMOTE_LIB_INPUT_DATA, *PREMOTE_LIB_INPUT_DATA;
 
@@ -40,7 +40,7 @@ typedef struct _MULTIPLE_REMOTE_EXT {
 } MULTIPLE_REMOTE_EXT, *PMULTIPLE_REMOTE_EXT;
 
 BOOL CALLBACK kull_m_remotelib_callback_module_exportedEntry(PKULL_M_PROCESS_EXPORTED_ENTRY pExportedEntryInformations, PVOID pvArg);
-PREMOTE_LIB_INPUT_DATA kull_m_remotelib_CreateInput(PVOID inputVoid, DWORD inputDword, DWORD inputSize, LPCVOID inputData);
+PREMOTE_LIB_INPUT_DATA kull_m_remotelib_CreateInput(PVOID inputVoid, DWORD inputDword, DWORD_PTR inputSize, LPCVOID inputData);
 BOOL kull_m_remotelib_create(PKULL_M_MEMORY_ADDRESS aRemoteFunc, PREMOTE_LIB_INPUT_DATA input, PREMOTE_LIB_OUTPUT_DATA output);
 
 BOOL CALLBACK kull_m_remotelib_exports_callback_module_exportedEntry(PKULL_M_PROCESS_EXPORTED_ENTRY pExportedEntryInformations, PVOID pvArg);

--- a/modules/kull_m_string.c
+++ b/modules/kull_m_string.c
@@ -133,7 +133,7 @@ PCWCHAR WPRINTF_TYPES[] =
 	L"%02X",		// WPRINTF_HEX_SHORT_CAP
 };
 
-void kull_m_string_wprintf_hex(LPCVOID lpData, DWORD cbData, DWORD flags)
+void kull_m_string_wprintf_hex(LPCVOID lpData, DWORD_PTR cbData, DWORD flags)
 {
 	DWORD i, sep = flags >> 16;
 	PCWCHAR pType = WPRINTF_TYPES[flags & 0x0000000f];

--- a/modules/kull_m_string.h
+++ b/modules/kull_m_string.h
@@ -79,7 +79,7 @@ char * kull_m_string_unicode_to_ansi(const wchar_t * unicode);
 BOOL kull_m_string_stringToHex(IN LPCWCHAR string, IN LPBYTE hex, IN DWORD size);
 BOOL kull_m_string_stringToHexBuffer(IN LPCWCHAR string, IN LPBYTE *hex, IN DWORD *size);
 
-void kull_m_string_wprintf_hex(LPCVOID lpData, DWORD cbData, DWORD flags);
+void kull_m_string_wprintf_hex(LPCVOID lpData, DWORD_PTR cbData, DWORD flags);
 __time32_t kull_m_string_get_time32(__time32_t * _Time);
 void kull_m_string_displayFileTime(IN PFILETIME pFileTime);
 void kull_m_string_displayLocalFileTime(IN PFILETIME pFileTime);


### PR DESCRIPTION
Hi @gentilkiwi,

trying to build mimikatz (Release|x64) with Visual Studio Community 2019, I got the error you can see in the screenshot below

![mimikatz_pointer_truncation_x64](https://user-images.githubusercontent.com/15381185/155893575-96dbef06-6388-4e31-b28e-bb90f5998a4e.PNG)

I tried to solve it by changing where necessary the code.

By applying these changes I no longer get errors/warnings with both x64 and Win32. It would be necessary to understand if at runtime the result is the expected one or not.

Do you have any way to verify this for yourself? I could try it myself but I think it's better to leave this task to you :D

Let me know, thanks :)