### PR TITLE
Fix potential memory leaks

### DIFF
--- a/mimikatz/modules/kuhl_m_sid.c
+++ b/mimikatz/modules/kuhl_m_sid.c
@@ -260,9 +260,9 @@ void kuhl_m_sid_displayMessage(PLDAP ld, PLDAPMessage pMessage)
 
 	for(pEntry = ldap_first_entry(ld, pMessage); pEntry; pEntry = ldap_next_entry(ld, pEntry))
 	{
-        tmpLdapDn = ldap_get_dn(ld, pEntry);
+		tmpLdapDn = ldap_get_dn(ld, pEntry);
 		kprintf(L"\n%s\n", tmpLdapDn);
-        ldap_memfree(tmpLdapDn);
+		ldap_memfree(tmpLdapDn);
 		for(pAttribute = ldap_first_attribute(ld, pEntry, &pBer); pAttribute; pAttribute = ldap_next_attribute(ld, pEntry, pBer))
 		{
 			kprintf(L"  %s: ", pAttribute);

--- a/mimikatz/modules/kuhl_m_sid.c
+++ b/mimikatz/modules/kuhl_m_sid.c
@@ -256,10 +256,13 @@ void kuhl_m_sid_displayMessage(PLDAP ld, PLDAPMessage pMessage)
 	PBERVAL *pBerVal;
 	DWORD i;
 	SID_NAME_USE nameUse;
+	PWSTR tmpLdapDn;
 
 	for(pEntry = ldap_first_entry(ld, pMessage); pEntry; pEntry = ldap_next_entry(ld, pEntry))
 	{
-		kprintf(L"\n%s\n", ldap_get_dn(ld, pEntry));
+        tmpLdapDn = ldap_get_dn(ld, pEntry);
+		kprintf(L"\n%s\n", tmpLdapDn);
+        ldap_memfree(tmpLdapDn);
 		for(pAttribute = ldap_first_attribute(ld, pEntry, &pBer); pAttribute; pAttribute = ldap_next_attribute(ld, pEntry, pBer))
 		{
 			kprintf(L"  %s: ", pAttribute);

--- a/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
+++ b/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
@@ -218,7 +218,7 @@ BOOL kuhl_m_lsadump_dcsync_SearchAndParseLDAPToIntId(PLDAP ld, PWCHAR dn, PWCHAR
 		{
 			if(pEntry = ldap_first_entry(ld, pMessage))
 			{
-				tmpLdapDn = ldap_get_dn(ld, pEntry)
+				tmpLdapDn = ldap_get_dn(ld, pEntry);
 				kprintf(L"[ldap] %s : ", tmpLdapDn);
 				ldap_memfree(tmpLdapDn);
 				pId = ldap_get_values_len(ld, pEntry, myAttrs[0]);

--- a/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
+++ b/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
@@ -209,6 +209,7 @@ BOOL kuhl_m_lsadump_dcsync_SearchAndParseLDAPToIntId(PLDAP ld, PWCHAR dn, PWCHAR
 	PLDAPMessage pMessage = NULL, pEntry;
 	PBERVAL *pId;
 	PSTR tmpString;
+	PWSTR tmpLdapDn;
 
 	ret = ldap_search_s(ld, dn, LDAP_SCOPE_ONELEVEL, req, myAttrs, FALSE, &pMessage);
 	if(ret == LDAP_SUCCESS)
@@ -217,7 +218,9 @@ BOOL kuhl_m_lsadump_dcsync_SearchAndParseLDAPToIntId(PLDAP ld, PWCHAR dn, PWCHAR
 		{
 			if(pEntry = ldap_first_entry(ld, pMessage))
 			{
-				kprintf(L"[ldap] %s : ", ldap_get_dn(ld, pEntry));
+                tmpLdapDn = ldap_get_dn(ld, pEntry)
+				kprintf(L"[ldap] %s : ", tmpLdapDn);
+                ldap_memfree(tmpLdapDn);
 				pId = ldap_get_values_len(ld, pEntry, myAttrs[0]);
 				if(pId && pId[0])
 				{
@@ -1245,6 +1248,7 @@ BOOL kuhl_m_lsadump_dcshadow_build_convert_account_to_dn(PLDAP ld, PWSTR szDomai
 					status = TRUE;
 			}
 			ldap_msgfree(pMessage);
+            ldap_memfreeW(szDN);
 		}
 		LocalFree(szFilter);
 	}
@@ -1578,6 +1582,7 @@ NTSTATUS kuhl_m_lsadump_dcshadow_lingering_propagate(PDCSHADOW_DOMAIN_INFO info,
 		{
 			szNTDSADn = ldap_get_dn(info->ld, pEntry);
 			szServerDN = wcsstr(szNTDSADn, L",CN=") + 1;
+            ldap_memfree(szNTDSADn);
 			dwErr = ldap_search_s(info->ld, szServerDN, LDAP_SCOPE_BASE, NULL, szAttributes, FALSE, &pServerMessage);
 			if(dwErr == LDAP_SUCCESS)
 			{

--- a/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
+++ b/mimikatz/modules/lsadump/kuhl_m_lsadump_dc.c
@@ -218,9 +218,9 @@ BOOL kuhl_m_lsadump_dcsync_SearchAndParseLDAPToIntId(PLDAP ld, PWCHAR dn, PWCHAR
 		{
 			if(pEntry = ldap_first_entry(ld, pMessage))
 			{
-                tmpLdapDn = ldap_get_dn(ld, pEntry)
+				tmpLdapDn = ldap_get_dn(ld, pEntry)
 				kprintf(L"[ldap] %s : ", tmpLdapDn);
-                ldap_memfree(tmpLdapDn);
+				ldap_memfree(tmpLdapDn);
 				pId = ldap_get_values_len(ld, pEntry, myAttrs[0]);
 				if(pId && pId[0])
 				{
@@ -1248,7 +1248,7 @@ BOOL kuhl_m_lsadump_dcshadow_build_convert_account_to_dn(PLDAP ld, PWSTR szDomai
 					status = TRUE;
 			}
 			ldap_msgfree(pMessage);
-            ldap_memfreeW(szDN);
+			ldap_memfreeW(szDN);
 		}
 		LocalFree(szFilter);
 	}
@@ -1582,7 +1582,7 @@ NTSTATUS kuhl_m_lsadump_dcshadow_lingering_propagate(PDCSHADOW_DOMAIN_INFO info,
 		{
 			szNTDSADn = ldap_get_dn(info->ld, pEntry);
 			szServerDN = wcsstr(szNTDSADn, L",CN=") + 1;
-            ldap_memfree(szNTDSADn);
+			ldap_memfree(szNTDSADn);
 			dwErr = ldap_search_s(info->ld, szServerDN, LDAP_SCOPE_BASE, NULL, szAttributes, FALSE, &pServerMessage);
 			if(dwErr == LDAP_SUCCESS)
 			{
@@ -3221,7 +3221,7 @@ ULONG SRV_IDL_DRSVerifyNames(DRS_HANDLE hDrs, DWORD dwInVersion, DRS_MSG_VERIFYR
 	pmsgOut->V1.cNames = pmsgIn->V1.cNames;
 	pmsgOut->V1.rpEntInf = (ENTINF*)MIDL_user_allocate(sizeof(ENTINF) * pmsgIn->V1.cNames);
 	ZeroMemory(pmsgOut->V1.rpEntInf, sizeof(ENTINF) * pmsgIn->V1.cNames);
-    return ERROR_SUCCESS;
+	return ERROR_SUCCESS;
 }
 
 // this function is here to acknowledge that we add a DC in our own replication list


### PR DESCRIPTION
As outlined by @rachyyyy in

https://github.com/gentilkiwi/mimikatz/issues/406 and https://github.com/gentilkiwi/mimikatz/issues/405

Anything that calls `ldap_get_dn` must be freed. There are several other implementations of this method that do get freed in the codebase, so it looks like it was just missed in a couple of places.