### PR TITLE
[fix] kuhl_m_kerberos: really used KerbQueryTicketCacheExMessage.

### DIFF
--- a/mimikatz/modules/kerberos/kuhl_m_kerberos.c
+++ b/mimikatz/modules/kerberos/kuhl_m_kerberos.c
@@ -259,9 +259,9 @@ NTSTATUS kuhl_m_kerberos_list(int argc, wchar_t * argv[])
 			}
 			LsaFreeReturnBuffer(pKerbCacheResponse);
 		}
-		else PRINT_ERROR(L"LsaCallAuthenticationPackage KerbQueryTicketCacheEx2Message / Package : %08x\n", packageStatus);
+		else PRINT_ERROR(L"LsaCallAuthenticationPackage KerbQueryTicketCacheExMessage / Package : %08x\n", packageStatus);
 	}
-	else PRINT_ERROR(L"LsaCallAuthenticationPackage KerbQueryTicketCacheEx2Message : %08x\n", status);
+	else PRINT_ERROR(L"LsaCallAuthenticationPackage KerbQueryTicketCacheExMessage : %08x\n", status);
 
 	return STATUS_SUCCESS;
 }


### PR DESCRIPTION
Replace KerbQueryTicketCacheEx2 Message with KerbQueryTicketCacheExMessage (that is really was called) in error messages.