### PR TITLE
Fix for out of order encrypted_key in local state

### DIFF
--- a/mimikatz/modules/dpapi/packages/kuhl_m_dpapi_chrome.c
+++ b/mimikatz/modules/dpapi/packages/kuhl_m_dpapi_chrome.c
@@ -252,9 +252,9 @@ BOOL kuhl_m_dpapi_chrome_alg_key_from_file(LPCWSTR szState, BOOL forced, int arg
 	{
 		if(uData = kull_m_string_qad_ansi_c_to_unicode((const char *) data, dwData))
 		{
-			if(begin = wcsstr(uData, L"\"os_crypt\":{\"encrypted_key\":\""))
+			if(begin = wcsstr(uData, L"\"encrypted_key\":\""))
 			{
-				begin += 29;
+				begin += 17;
 				if(end = wcsstr(begin, L"\"}"))
 				{
 					end = L'\0';
@@ -263,7 +263,7 @@ BOOL kuhl_m_dpapi_chrome_alg_key_from_file(LPCWSTR szState, BOOL forced, int arg
 				}
 				else PRINT_ERROR(L"Unable to find the end of the encrypted_key\n");
 			}
-			else if(forced) PRINT_ERROR(L"encrypted_key not fond in state file.\n");
+			else if(forced) PRINT_ERROR(L"encrypted_key not found in state file.\n");
 			LocalFree(uData);
 		}
 		LocalFree(data);


### PR DESCRIPTION
os_crypt can contain multiple fields, and encrypted_key is not guarenteed to be first

however, to my knowledge, encrypted_key as a field name is only in local state _once_ so simply searching for that alone should suffice.